### PR TITLE
Update xray.json

### DIFF
--- a/etc/xray.json
+++ b/etc/xray.json
@@ -67,7 +67,8 @@
         {
             "protocol": "freedom",
             "settings": {
-                "domainStrategy": "UseIPv4"
+                "domainStrategy": "UseIPv4",
+                "userLevel": 0
             }
         },
         {

--- a/etc/xray.json
+++ b/etc/xray.json
@@ -1,52 +1,105 @@
 {
-    "inbounds": 
-    [
-        {
-            "listen": "/etc/caddy/vmess","protocol": "vmess",
-            "settings": {"clients": [{"id": "$AUUID"}]},
-            "streamSettings": {"network": "ws","wsSettings": {"path": "/$AUUID-vmess"}}
+    "log": {
+        "loglevel": "none"
+    },
+    "inbounds": [
+        {   
+            "listen": "/etc/caddy/vless",
+            "protocol": "vless",
+            "settings": {
+                "clients": [
+                    {
+                        "id": "$ID",
+                        "level": 0,
+                        "email": "love@v2fly.org"
+                    }
+                ],
+                "decryption": "none"
+            },
+            "streamSettings": {
+                "network": "ws",
+                "allowInsecure": false,
+                "wsSettings": {
+                  "path": "/$ID-vless"
+                }
+            }
         },
-        {
-            "listen": "/etc/caddy/vless","protocol": "vless",
-            "settings": {"clients": [{"id": "$AUUID"}],"decryption": "none"},
-            "streamSettings": {"network": "ws","wsSettings": {"path": "/$AUUID-vless"}}
-        },
-        {
-            "listen": "/etc/caddy/trojan","protocol": "trojan",
-            "settings": {"clients": [{"password":"$AUUID"}]},
-            "streamSettings": {"network": "ws","wsSettings": {"path": "/$AUUID-trojan"}}
-        },
-        {
-            "port": 4234,"listen": "127.0.0.1","tag": "onetag","protocol": "dokodemo-door",
-            "settings": {"address": "v1.mux.cool","network": "tcp","followRedirect": false},
-            "streamSettings": {"security": "none","network": "ws","wsSettings": {"path": "/$AUUID-ss"}}
-        },
-        {
-            "port": 4324,"listen": "127.0.0.1","protocol": "shadowsocks",
-            "settings": {"method": "$ParameterSSENCYPT","password": "$AUUID"},
-            "streamSettings": {"security": "none","network": "domainsocket","dsSettings": {"path": "apath","abstract": true}}
-        },
-        {   "port": 5234,"listen": "127.0.0.1","protocol": "socks",
-            "settings": {"auth": "password","accounts": [{"user": "$AUUID","pass": "$AUUID"}]},
-            "streamSettings": {"network": "ws","wsSettings": {"path": "/$AUUID-socks"}}
+        {   
+            "listen": "/etc/caddy/trojan",
+            "protocol": "trojan",
+            "settings": {
+                "clients": [
+                    {
+                        "password":"$ID",
+                        "level": 0,
+                        "email": "love@v2fly.org"
+                    }
+                ],
+                "decryption": "none"
+            },
+            "streamSettings": {
+                "network": "ws",
+                "allowInsecure": false,
+                "wsSettings": {
+                  "path": "/$ID-trojan"
+                }
+            }
         }
     ],
-    
-    "outbounds": 
-    [
-        {"protocol": "freedom","tag": "direct","settings": {}},
-        {"protocol": "blackhole","tag": "blocked","settings": {}},
-        {"protocol": "socks","tag": "sockstor","settings": {"servers": [{"address": "127.0.0.1","port": 9050}]}},
-        {"protocol": "freedom","tag": "twotag","streamSettings": {"network": "domainsocket","dsSettings": {"path": "apath","abstract": true}}}    
-    ],
-    
-    "routing": 
-    {
-        "rules": 
-        [
-            {"type": "field","inboundTag": ["onetag"],"outboundTag": "twotag"},
-            {"type": "field","outboundTag": "sockstor","domain": ["geosite:tor"]},
-            {"type": "field","outboundTag": "blocked","domain": ["geosite:category-ads-all"]}
+    "routing": {
+        "domainStrategy": "IPIfNonMatch",
+        "domainMatcher": "mph",
+        "rules": [
+           {
+              "type": "field",
+              "protocol": [
+                 "bittorrent"
+              ],
+              "domains": [
+                  "geosite:cn",
+                  "geosite:category-ads-all"
+              ],
+              "outboundTag": "blocked"
+           }
         ]
+    },
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "settings": {
+                "domainStrategy": "UseIPv4"
+            }
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "blocked"
+        }
+    ],
+    "dns": {
+        "servers": [
+            {
+                "address": "8.8.4.4",
+                "port": 53,
+                "skipFallback": true,
+                "domains": [
+                    "geosite:!cn"
+                ],
+                "expectIPs": [
+                    "geoip:cn"
+                ]
+            },
+            {
+                "address": "1.1.1.1",
+                "port": 53,
+                "skipFallback": true,
+                "domains": [
+                    "geosite:!cn",
+                ],
+                "expectIPs": [
+                    "geoip:cn"
+                ]
+            }
+        ],
+        "queryStrategy": "UseIPv4"
     }
 }


### PR DESCRIPTION
重新添加vless和trojan连接方式（supported by v2fly-core native）

新增dns和路由解析模块

默认不转发来自cn的ip和域名

阻止bt协议